### PR TITLE
Use proper capitalisation of CC and ODbL licenses

### DIFF
--- a/android/app/src/main/res/values-da/strings.xml
+++ b/android/app/src/main/res/values-da/strings.xml
@@ -50,7 +50,7 @@
 	<string name="strenghtDbmCaption">Styrke (dbm)</string>
 	<string name="radiobeacon_licence">Licenseret under AGPL v3</string>
 	<string name="openbmap_licence_caption">Data: OpenBmap</string>
-	<string name="openbmap_license">CC-by-SA 3.0 / Odbl licens</string>
+	<string name="openbmap_license">CC BY-SA 3.0 / ODbL licens</string>
 	<string name="mapsforge_source">Kort bibliotek: Mapsforge bibliotek</string>
 	<string name="mapsforge_license">GNU LGPL3 licens</string>
 	<string name="map_data_source">Kortdata: Openstreetmap</string>

--- a/android/app/src/main/res/values-de/strings.xml
+++ b/android/app/src/main/res/values-de/strings.xml
@@ -16,14 +16,14 @@
     <string name="graph_title">Signalstärke Funkzelle</string>
     <string name="info_using_online_map">Keine Offlinekarte gefunden. Verwende Onlineverbindung</string>
     <string name="is_new">Neu?</string>
-    <string name="map_data_license">Odbl Lizenz</string>
+    <string name="map_data_license">ODbL Lizenz</string>
     <string name="map_data_source">Kartendaten: Openstreetmap</string>
     <string name="mapsforge_license">GNU LGPL3 Lizenz</string>
     <string name="networkTypeCaption">Technologie</string>
     <string name="new_session">Neue Session</string>
     <string name="no">Nein</string>
     <string name="no_sat_signal">Kein Sat-Signal</string>
-    <string name="openbmap_license">CC-by-SA 3.0 / Odbl Lizenz</string>
+    <string name="openbmap_license">CC BY-SA 3.0 / ODbL Lizenz</string>
     <string name="prefs_clean_database_title">Datenbank optimieren</string>
     <string name="prefs_credentials_password">Passwort</string>
     <string name="prefs_credentials_user">User</string>

--- a/android/app/src/main/res/values-es/strings.xml
+++ b/android/app/src/main/res/values-es/strings.xml
@@ -41,12 +41,12 @@
 	<string name="strenghtDbmCaption">Fuerza (dbm)</string>
 	<string name="radiobeacon_licence">Licenciado bajo AGPL v3</string>
 	<string name="openbmap_licence_caption">Datos: OpenBmap</string>
-	<string name="openbmap_license">CC-by-SA 3.0 / Licencia Odbl</string>
+	<string name="openbmap_license">CC BY-SA 3.0 / Licencia ODbL</string>
 	<string name="mapsforge_source">Librería de mapas: Librería Mapsforge</string>
 	<string name="mapsforge_license">Licencia GNU LGPL3</string>
 	<string name="credits">Créditos</string>
 	<string name="map_data_source">Datos del mapa: OpenStreetMap</string>
-	<string name="map_data_license">Licencia Odbl</string>
+	<string name="map_data_license">Licencia ODbL</string>
 	<string name="sessions">Sesiones</string>
 	<string name="n_a">S/D</string>
 	<string name="frequency">Frecuencia</string>

--- a/android/app/src/main/res/values-hu/strings.xml
+++ b/android/app/src/main/res/values-hu/strings.xml
@@ -41,7 +41,7 @@
 	<string name="is_serving_cell_caption">Kiszolgáló cella?</string>
 	<string name="radiobeacon_licence">AGPL v3 alatt licencelve</string>
 	<string name="openbmap_licence_caption">Adatok: OpenBmap</string>
-	<string name="openbmap_license">CC-by-SA 3.0 / Odbl Licenc</string>
+	<string name="openbmap_license">CC BY-SA 3.0 / ODbL Licenc</string>
 	<string name="mapsforge_source">Térkép könyvtár: Mapsforge Library</string>
 	<string name="mapsforge_license">GNU LGPL3 licenc</string>
 	<string name="credits">Köszönet</string>

--- a/android/app/src/main/res/values-it/strings.xml
+++ b/android/app/src/main/res/values-it/strings.xml
@@ -17,10 +17,10 @@
 	<string name="is_serving_cell_caption">Attualmente connessa?</string>
 	<string name="radiobeacon_licence">Offerto secondo i termini della licenza AGPL v3</string>
 	<string name="openbmap_licence_caption">Dati forniti da Openbmap</string>
-	<string name="openbmap_license">sotto licenza CC-BY-SA 3.0 / ODBL</string>
+	<string name="openbmap_license">sotto licenza CC BY-SA 3.0 / ODbL</string>
 	<string name="mapsforge_license">sotto licenza LGPL v3</string>
 	<string name="map_data_source">Mappe: OpenStreetMap</string>
-	<string name="map_data_license">sotto licenza ODBL</string>
+	<string name="map_data_license">sotto licenza ODbL</string>
 	<string name="other_credits">"Ringraziamo tutti i contributori ed i traduttori!\nIn particolare il team di Mapsforge e gli sviluppatori di OSMTracker. "</string>
 	<string name="bug_report">"Troverai sempre l\'ultima versione (ed il servizio di bug report) su "</string>
 	<string name="sessions">Sessioni</string>

--- a/android/app/src/main/res/values-ja/strings.xml
+++ b/android/app/src/main/res/values-ja/strings.xml
@@ -58,12 +58,12 @@
 	<string name="is_serving_cell_caption">稼働中の基地局ですか?</string>
 	<string name="radiobeacon_licence">AGPL v3 の下でライセンスされます</string>
 	<string name="openbmap_licence_caption">データ: OpenBmap</string>
-	<string name="openbmap_license">CC-by-SA 3.0 / Odbl ライセンス</string>
+	<string name="openbmap_license">CC BY-SA 3.0 / ODbL ライセンス</string>
 	<string name="mapsforge_source">マップ ライブラリー: Mapsforge ライブラリー</string>
 	<string name="mapsforge_license">GNU LGPL3 ライセンス</string>
 	<string name="credits">クレジット</string>
 	<string name="map_data_source">マップ データ: Openstreetmap</string>
-	<string name="map_data_license">Odbl ライセンス</string>
+	<string name="map_data_license">ODbL ライセンス</string>
 	<string name="other_credits">"すべての貢献者と翻訳者のおかげです!\n特に Mapsforge の人々と OSMTracker の開発者に感謝します。 "</string>
 	<string name="bug_report">"常に最新バージョン (およびバグ追跡システム) を見つける "</string>
 	<string name="subtitle">OpenBmap Wifi &amp; 基地局ログ取得</string>

--- a/android/app/src/main/res/values-pl/strings.xml
+++ b/android/app/src/main/res/values-pl/strings.xml
@@ -65,12 +65,12 @@
     <string name="is_serving_cell_caption">Is serving cell?</string>
     <string name="radiobeacon_licence">Pod licencją AGPL v3</string>
     <string name="openbmap_licence_caption">Dane: OpenBmap</string>
-    <string name="openbmap_license">Licencja CC-by-SA 3.0 / Licencja Odbl</string>
+    <string name="openbmap_license">Licencja CC BY-SA 3.0 / Licencja ODbL</string>
     <string name="mapsforge_source">Biblioteka map: Mapsforge Library</string>
     <string name="mapsforge_license">Licencja GNU LGPL3</string>
     <string name="credits">Uznanie</string>
     <string name="map_data_source">Dane map: Openstreetmap</string>
-    <string name="map_data_license">Licencja Odbl</string>
+    <string name="map_data_license">Licencja ODbL</string>
 	<string name="other_credits">Niektóre wspaniałe pomysły były wzięte z OSMTracker, dyskusji stack overflow i wielu, wielu innych</string>
 	<string name="bug_report">Znajdź zawsze najnowszą wersję (i sledzenie błędów) na</string>
     <string name="subtitle">OpenBmap Wifi &amp; Cell Logger</string>

--- a/android/app/src/main/res/values-zh-rCN/strings.xml
+++ b/android/app/src/main/res/values-zh-rCN/strings.xml
@@ -49,12 +49,12 @@
 	<string name="strenghtDbmCaption">强度 (dbm)</string>
 	<string name="radiobeacon_licence">许可协议 AGPL v3</string>
 	<string name="openbmap_licence_caption">数据：OpenBmap</string>
-	<string name="openbmap_license">CC-by-SA 3.0 / Odbl 许可协议</string>
+	<string name="openbmap_license">CC BY-SA 3.0 / ODbL 许可协议</string>
 	<string name="mapsforge_source">地图库：Mapsforge 库</string>
 	<string name="mapsforge_license">GNU LGPL3 许可协议</string>
 	<string name="credits">贡献人员</string>
 	<string name="map_data_source">地图数据：Openstreetmap</string>
-	<string name="map_data_license">Odbl 许可协议</string>
+	<string name="map_data_license">ODbL 许可协议</string>
 	<string name="sessions">会话</string>
 	<string name="n_a">不可用</string>
 	<string name="capabilities">能力</string>

--- a/android/app/src/main/res/values/strings.xml
+++ b/android/app/src/main/res/values/strings.xml
@@ -73,12 +73,12 @@
     <string name="is_serving_cell_caption">Is serving cell?</string>
     <string name="radiobeacon_licence">Licensed under AGPL v3</string>
     <string name="openbmap_licence_caption">Data: RadioCells</string>
-    <string name="openbmap_license">CC-by-SA 3.0 / Odbl Licence</string>
+    <string name="openbmap_license">CC BY-SA 3.0 / ODbL Licence</string>
     <string name="mapsforge_source">Maps library: MapsForge Library</string>
     <string name="mapsforge_license">GNU LGPL v3 licence</string>
     <string name="credits">Credits</string>
     <string name="map_data_source">Map data: OpenStreetMap</string>
-    <string name="map_data_license">Odbl Licence</string>
+    <string name="map_data_license">ODbL Licence</string>
     <string name="other_credits">Many thanks to all the contributors and translators!\nSpecial thanks to the MapsForge people and the OSMTracker developers.</string>
     <string name="bug_report">Always find the latest version (and the issue tracker) at </string>
     <string name="subtitle">RadioCells WiFi &amp; Cell Logger</string>


### PR DESCRIPTION
See https://creativecommons.org/licenses/by-sa/3.0/ and https://opendatacommons.org/licenses/odbl/ for reference on how the license authors capitalise the license abbreviations.